### PR TITLE
fix: Search 페이지 내 검색 미동작 오류 해결

### DIFF
--- a/client/src/components/search-section/SearchSecion.jsx
+++ b/client/src/components/search-section/SearchSecion.jsx
@@ -42,7 +42,7 @@ const SearchSection = () => {
     };
 
     getContent();
-  }, []);
+  }, [search]);
 
   return (
     <Main>


### PR DESCRIPTION
- search 페이지 내 useEffect가 동작하지 않는 것을 확인
- useEffect 내에 search 의존성을 추가하여 해결

## 작업 내역
<!-- 이슈 번호 기록 -->

## 특이 사항
<!-- 버그 존재 시 이슈 번호 기록 -->


<!-- 리뷰어 지정 -->
