### PR TITLE
fix: 검색 결과 페이지 이동 버튼 크기 수정

### DIFF
--- a/client/src/components/search-section/search-section-components/ResultFooter.jsx
+++ b/client/src/components/search-section/search-section-components/ResultFooter.jsx
@@ -36,6 +36,12 @@ const IndexDiv = styled.div`
 `;
 
 const StyledLink = styled(Link)`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
   color: #0055fb;
   font-style: normal;
   font-weight: normal;


### PR DESCRIPTION
- width: 100%, height: 100%을 준다음 flex center로 가운데 정렬하여 해결

## 작업 내역
<!-- 이슈 번호 기록 -->

## 특이 사항
<!-- 버그 존재 시 이슈 번호 기록 -->


<!-- 리뷰어 지정 -->
