### PR TITLE
feat : 목차 및 문서 헤더에 id생성

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -24,6 +24,7 @@
         "react-markdown": "^7.1.0",
         "react-router-dom": "^5.3.0",
         "react-scripts": "4.0.3",
+        "rehype-indexes": "^0.0.20",
         "remark": "^14.0.1",
         "remark-gfm": "^3.0.0",
         "strip-markdown": "^5.0.0",
@@ -18679,6 +18680,14 @@
       "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
       "bin": {
         "jsesc": "bin/jsesc"
+      }
+    },
+    "node_modules/rehype-indexes": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/rehype-indexes/-/rehype-indexes-0.0.20.tgz",
+      "integrity": "sha512-yKdU3wxvwd4ncu4NdpKRWv+HOj58RrUqm9NApbEGpktEx/km15aJthJuHvuLjyB0P+reKdBzcNkZ1tiTrhUxsw==",
+      "dependencies": {
+        "unist-util-visit": "^4.1.0"
       }
     },
     "node_modules/relateurl": {
@@ -38365,6 +38374,14 @@
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
         }
+      }
+    },
+    "rehype-indexes": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/rehype-indexes/-/rehype-indexes-0.0.20.tgz",
+      "integrity": "sha512-yKdU3wxvwd4ncu4NdpKRWv+HOj58RrUqm9NApbEGpktEx/km15aJthJuHvuLjyB0P+reKdBzcNkZ1tiTrhUxsw==",
+      "requires": {
+        "unist-util-visit": "^4.1.0"
       }
     },
     "relateurl": {

--- a/client/package.json
+++ b/client/package.json
@@ -19,6 +19,7 @@
     "react-markdown": "^7.1.0",
     "react-router-dom": "^5.3.0",
     "react-scripts": "4.0.3",
+    "rehype-indexes": "^0.0.20",
     "remark": "^14.0.1",
     "remark-gfm": "^3.0.0",
     "strip-markdown": "^5.0.0",

--- a/client/src/components/MdParser.jsx
+++ b/client/src/components/MdParser.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import rehypeIndex from 'rehype-indexes';
 
 import styled from 'styled-components';
 
@@ -39,7 +40,9 @@ const MdParserContainer = styled.div`
 const MdParser = ({ content }) => {
   return (
     <MdParserContainer>
-      <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+      <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[[rehypeIndex, { mode: 'document' }]]}>
+        {content}
+      </ReactMarkdown>
     </MdParserContainer>
   );
 };

--- a/client/src/components/WikiContentsIndex.jsx
+++ b/client/src/components/WikiContentsIndex.jsx
@@ -1,11 +1,12 @@
 import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import ReactMarkdown from 'react-markdown';
+import rehypeIndexes from 'rehype-indexes';
 
 const Index = styled.div`
+  h1,
   h2,
-  h3,
-  h4 {
+  h3 {
     font-size: 16px;
     font-weight: 400;
     line-height: 23px;
@@ -13,14 +14,17 @@ const Index = styled.div`
     display: block;
     margin: 0px;
   }
-  h2 {
+  h1 {
     padding-left: 0px;
   }
-  h3 {
+  h2 {
     padding-left: 20px;
   }
-  h4 {
+  h3 {
     padding-left: 40px;
+  }
+  a {
+    margin-right: 4px;
   }
   padding: 12px 20px 18px 0;
   border: 2px solid #d7d7d7;
@@ -43,9 +47,7 @@ const WikiContentsIndex = ({ text, title }) => {
     <Index>
       <Title> {title}</Title>
       <Padd>
-        <ReactMarkdown allowedElements={['h1', 'h2', 'h3']} components={{ h1: 'h2', h2: 'h3', h3: 'h4' }}>
-          {text}
-        </ReactMarkdown>
+        <ReactMarkdown rehypePlugins={[rehypeIndexes]}>{text}</ReactMarkdown>
       </Padd>
     </Index>
   );

--- a/client/src/components/wiki-section/WikiSection.jsx
+++ b/client/src/components/wiki-section/WikiSection.jsx
@@ -58,7 +58,7 @@ const WikiSection = ({ generation, boostcampId, name }) => {
           <Padd>
             <WikiContentsIndex title="목차" text={docData.content} />
             <WikiCard docData={docData} name={name} />
-          </Padd> 
+          </Padd>
 
           <MdParser content={docData.content} />
         </>


### PR DESCRIPTION
## 작업 내역

- 문서 내 링크이동 가능
- 문서 헤더에 img,a 등 메타 정보 포함시 naive 하게 출력
- 문서 목차에 번호 출력



