### PR TITLE
feat: 문서 수정 기능 구현

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,6 +5,7 @@ import MakePage from './pages/MakePage';
 import SearchPage from './pages/SearchPage';
 import ErrorPage from './pages/ErrorPage';
 import WikiPage from './pages/WikiPage';
+import UpdatePage from './pages/UpdatePage';
 import { selectTgInitState, selectTgReducer } from './reducer/select-toggle-reducer';
 import { selectTypeInitState, selectTypeReducer } from './reducer/select-type-reducer';
 import { selectHandler } from './event-handler/select-handler';
@@ -32,6 +33,7 @@ const App = () => {
             <Route path="/search" component={SearchPage} />
             <Route path="/error" component={ErrorPage} />
             <Route path="/w" component={WikiPage} />
+            <Route path="/updatedocs" component={UpdatePage} />
             <Route path="/" component={ErrorPage} />
           </Switch>
         </Router>

--- a/client/src/components/make-section/UpdateSection.jsx
+++ b/client/src/components/make-section/UpdateSection.jsx
@@ -23,13 +23,14 @@ const UpdateSection = ({history, generation, boostcampId, name}) => {
     if (!docRule) alert('규정에 동의해주세요');
     else {
       await fetch('/documents', {
-        method: 'POST',
+        method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify(docData),
       }).then((res) => res.json());
-      history.push(`/w/${docData.generation}_${docData.boostcamp_id}_${docData.name}`);
+      // history.push(`/w/${docData.generation}_${docData.boostcamp_id}_${docData.name}`);
+      history.goBack();
     }
   };
 
@@ -39,7 +40,16 @@ const UpdateSection = ({history, generation, boostcampId, name}) => {
 
   useEffect(() => {
     // 문서 정보 받아와서 docData에 데이터 추가하기
-    console.log('hello');
+    const getContent = async () => {
+      const res = await fetch(`/documents/?generation=${generation}&boostcamp_id=${boostcampId}&name=${name}`);
+      if (res.status !== 200){
+        history.push('/error');
+      }
+      const { result } = await res.json();
+      docDispatch({type: 'INPUT_DOC_DATA', ...result[0] })
+    }
+
+    getContent();
   }, [])
 
   return (

--- a/client/src/components/make-section/UpdateSection.jsx
+++ b/client/src/components/make-section/UpdateSection.jsx
@@ -19,9 +19,10 @@ const UpdateSection = ({history, generation, boostcampId, name}) => {
     else setDocRule(false);
   };
 
-  const addDocument = async () => {
+  const updateDocument = async () => {
     if (!docRule) alert('규정에 동의해주세요');
     else {
+      console.log(docData);
       await fetch('/documents', {
         method: 'PUT',
         headers: {
@@ -29,7 +30,6 @@ const UpdateSection = ({history, generation, boostcampId, name}) => {
         },
         body: JSON.stringify(docData),
       }).then((res) => res.json());
-      // history.push(`/w/${docData.generation}_${docData.boostcamp_id}_${docData.name}`);
       history.goBack();
     }
   };
@@ -46,7 +46,21 @@ const UpdateSection = ({history, generation, boostcampId, name}) => {
         history.push('/error');
       }
       const { result } = await res.json();
-      docDispatch({type: 'INPUT_DOC_DATA', ...result[0] })
+      const updateData = {
+        type: 'INPUT_UPDATE_DATA',
+        name,
+        generation,
+        boostcamp_id: boostcampId,
+        content: result[0].content,
+        field: result[0].field,
+        language: result[0].language,
+        link: result[0].link,
+        location: result[0].location,
+        mbti: result[0].mbti,
+        nickname: result[0].nickname,
+        user_image: result[0].user_image,
+      }
+      docDispatch(updateData);
     }
 
     getContent();
@@ -68,7 +82,7 @@ const UpdateSection = ({history, generation, boostcampId, name}) => {
         </RuleDiv>
 
         <ButtonWrap>
-          <SubmitBtn onClick={addDocument}>등록</SubmitBtn>
+          <SubmitBtn onClick={updateDocument}>등록</SubmitBtn>
           <CancelBtn onClick={cancelAddDoc}>취소</CancelBtn>
         </ButtonWrap>
 

--- a/client/src/components/make-section/make-section-components/DocCard.jsx
+++ b/client/src/components/make-section/make-section-components/DocCard.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import styled from "styled-components";
 import { BREAK_POINT_MOBILE } from '../../../magic-number';
 import noImg from '../../../resource/img/no-image.png';
@@ -34,20 +34,25 @@ const DocCard = ({docData, docDispatch}) => {
   return (
     <CardBox>
 
-      <CardOwner type='text' placeholder={docData.name === '' ? '이름을 입력하세요' : docData.name} readOnly />
+      <CardOwner type='text' placeholder={docData.name} readOnly />
 
-      <CardImg src={docData.user_image !== null ? docData.user_image : noImg} />
+      <CardImg src={(docData.user_image === null || docData.user_image === 'null') ? noImg : docData.user_image} />
 
       {cardData.map((item) => (
         <CardDataWrap key={item.name}>
           <CardDataName>{item.name}</CardDataName>
-          <CardDataInput placeholder='입력하세요' onChange={dataValueChange} id={item.key} autoComplete='off' />
+          <CardDataInput 
+            placeholder='입력하세요'
+            onChange={dataValueChange} 
+            id={item.key}
+            autoComplete='off' 
+            value={(docData[item.key] === 'null' || !docData[item.key]) ? '' : docData[item.key]} />
         </CardDataWrap>
       ))}
 
       <CardDataWrap>
         <CardDataName>MBTI</CardDataName>
-        <MbtiSelector defaultValue='default' onChange={dataValueChange} id='mbti'>
+        <MbtiSelector value={(docData.mbti === 'null' || docData.mbti === null) ? 'default' : docData.mbti} onChange={dataValueChange} id='mbti'>
           <option value='default' disabled style={{color: '#888888'}}>선택하세요</option>
           {MBTI.map((type) => (<option key={type} value={type}>{type}</option>))}
         </MbtiSelector>

--- a/client/src/components/wiki-section/WikiSection.jsx
+++ b/client/src/components/wiki-section/WikiSection.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 import MainSection from '../common/MainSection'
 import Loading from '../Loading';
@@ -14,6 +14,10 @@ const WikiSection = ({ generation, boostcampId, name, location }) => {
   const [loading, setLoading] = useState(true);
   const history = useHistory();
   const id = generation + boostcampId + name;
+
+  // const updateDoc = () => {
+  //   history.push(`/updatedocs/${generation}_${boostcampId}_${name}`);
+  // }
 
   useEffect(() => {
     const getContent = async () => {
@@ -38,6 +42,10 @@ const WikiSection = ({ generation, boostcampId, name, location }) => {
             <WikiContentsIndex title="목차" text={docData.content} />
             <WikiCard docData={docData} name={name} />
           </Padd>
+          <Link to={`/updatedocs/${generation}_${boostcampId}_${name}`}>
+            <input type='button' value='수정' />
+          </Link>
+          
 
           <MdParser content={docData.content} />
         </>

--- a/client/src/pages/UpdatePage.jsx
+++ b/client/src/pages/UpdatePage.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import PageLayout from './common/PageLayout';
+import UpdateSection from '../components/make-section/UpdateSection';
+
+const getDocumentInfo = (pathname) => {
+  const result = pathname.match(/\/updatedocs\/(?<generation>\d+)_(?<boostcampId>.+)_(?<name>.+)/);
+  return result.groups;
+};
+
+const UpdatePage = ({ history, location }) => {
+  const result = getDocumentInfo(location.pathname);
+  return (
+    <PageLayout>
+      <UpdateSection history={history} name={result.name} generation={result.generation} boostcampId={result.boostcampId} />
+    </PageLayout>
+  );
+};
+
+export default UpdatePage;

--- a/client/src/reducer/doc-data-reducer.ts
+++ b/client/src/reducer/doc-data-reducer.ts
@@ -56,8 +56,8 @@ export const docDataReducer = (state: DocData, action: any): DocData => {
       return { ...state, field: action.field };
     case 'INPUT_LINK':
       return { ...state, link: action.link };
-    case 'INPUT_DOC_DATA':
-      return {...state, ...action };
+    case 'INPUT_UPDATE_DATA':
+      return {...state, generation: action.generation, boostcamp_id: action.boostcamp_id, name: action.name, content: action.content, user_image: action.user_image, nickname: action.nickname, location: action.location, language: action.language, mbti: action.mbti, field: action.field, link: action.link };
     default:
       return state;
   }

--- a/client/src/reducer/doc-data-reducer.ts
+++ b/client/src/reducer/doc-data-reducer.ts
@@ -56,6 +56,8 @@ export const docDataReducer = (state: DocData, action: any): DocData => {
       return { ...state, field: action.field };
     case 'INPUT_LINK':
       return { ...state, link: action.link };
+    case 'INPUT_DOC_DATA':
+      return {...state, ...action };
     default:
       return state;
   }

--- a/server/src/api/documents.ts
+++ b/server/src/api/documents.ts
@@ -1,6 +1,7 @@
 import * as express from 'express';
 import {
   createDoc,
+  updateDoc,
   getRecentUpdatedDoc,
   getTopViewedDoc,
   getSearchDoc,
@@ -34,6 +35,11 @@ router.post('/', async (req: express.Request, res: express.Response) => {
   let query: DocumentsCreate = req.body;
   query.user_id = 'zoeas';
   OnDocCreate(query);
+});
+
+router.put('/', async (req: express.Request, res: express.Response) => {
+  let result = await updateDoc(req.body);
+  res.status(200).json({ msg: 'OK', result: result });
 });
 
 router.get('/search', async (req: express.Request, res: express.Response) => {

--- a/server/src/sql/documents-query.ts
+++ b/server/src/sql/documents-query.ts
@@ -34,6 +34,14 @@ export async function createDoc(params: DocumentsCreate) {
   return result;
 }
 
+export async function updateDoc(params: DocumentsCreate) {
+  let query = `UPDATE document SET ${Object.entries(params)
+      .map(([key, value]) => `${key}='${value}'`)
+      .join(', ')} WHERE generation='${params.generation}' AND boostcamp_id='${params.boostcamp_id}' AND name='${params.name}'`;
+  const result = await db.pool.query(query);
+  return result;
+}
+
 export async function getSearchDoc(params: DocumentsSearch): Promise<DocumentsSearch[]> {
   const { generation, boostcamp_id, name, content, offset = 0, limit = 8 } = params;
   if (Object.values(params).every((el) => el === undefined)) {


### PR DESCRIPTION
## 작업 내역
- 문서 수정 기능 기본적인 라우팅 구현
- 문서 열람 페이지에서 수정 버튼을 누르면 수정 페이지로 라우팅
- 문서 수정 페이지로 라우팅 되면 기존 정보가 그대로 유지되도록 구현
- 문서 수정 이후 등록 버튼을 누르면 다시 해당 문서로 이동
<!-- 이슈 번호 기록 -->
#95 
## 특이 사항
<!-- 버그 존재 시 이슈 번호 기록 -->


<!-- 리뷰어 지정 -->
