### PR TITLE
feat, refactor : 본문 이미지 추가 버튼 구현, 이미지 최적화 진행

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@material-ui/core": "^4.12.3",
         "dotenv": "^10.0.0",
+        "browser-image-compression": "^1.0.17",
         "node-sass": "^6.0.1",
         "query-string": "^7.0.1",
         "react": "^17.0.2",
@@ -5742,6 +5743,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+    },
+    "node_modules/browser-image-compression": {
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-1.0.17.tgz",
+      "integrity": "sha512-TMDh3gyNlVA5Vvn0D0AdWr33s2ftIeokHK406z8cYlLJ4ANAq1x6eMaSzqedDoZwUGyTVB+0rhNVaSFgM3YAZg==",
+      "dependencies": {
+        "core-js": "^3.16.1",
+        "uzip": "0.20201231.0"
+      }
     },
     "node_modules/browser-process-hrtime": {
       "version": "1.0.0",
@@ -22634,6 +22644,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng=="
+    },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -28836,6 +28851,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+    },
+    "browser-image-compression": {
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-1.0.17.tgz",
+      "integrity": "sha512-TMDh3gyNlVA5Vvn0D0AdWr33s2ftIeokHK406z8cYlLJ4ANAq1x6eMaSzqedDoZwUGyTVB+0rhNVaSFgM3YAZg==",
+      "requires": {
+        "core-js": "^3.16.1",
+        "uzip": "0.20201231.0"
+      }
     },
     "browser-process-hrtime": {
       "version": "1.0.0",
@@ -41718,6 +41742,11 @@
           "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA=="
         }
       }
+    },
+    "uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/client/package.json
+++ b/client/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@material-ui/core": "^4.12.3",
     "dotenv": "^10.0.0",
+    "browser-image-compression": "^1.0.17",
     "node-sass": "^6.0.1",
     "query-string": "^7.0.1",
     "react": "^17.0.2",

--- a/client/src/components/common/MdParser.jsx
+++ b/client/src/components/common/MdParser.jsx
@@ -24,6 +24,8 @@ const MdParserContainer = styled.div`
   height: 100%;
 
   img {
+    width: fit-content;
+    height: fit-content;
     max-width: 100%;
     &:hover {
       cursor: pointer;

--- a/client/src/components/make-section/make-section-components/ContentImgUploadBtn.jsx
+++ b/client/src/components/make-section/make-section-components/ContentImgUploadBtn.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import { font, flexBox } from '../../../styles/styled-components/mixin';
 import { fileUploadValidator } from '../../../utils/validator';
 import { getImgUrl, showErrorCode } from '../../../services/image-upload';
 
@@ -45,7 +46,17 @@ const UploadBtn = styled.input`
 `;
 
 const UploadLabel = styled.label`
-  border: 1px solid red;
+  ${flexBox({ justifyContent: 'center', alignItems: 'center' })};
+  ${font({ size: '13px', weight: '500' })};
+  width: 80px;
+  height: 30px;
+  background-color: black;
+  color: white;
+  border-radius: 5px;
+
+  &:hover {
+    cursor: pointer;
+  }
 `;
 
 export default ContentImgUploadBtn;

--- a/client/src/components/make-section/make-section-components/ContentImgUploadBtn.jsx
+++ b/client/src/components/make-section/make-section-components/ContentImgUploadBtn.jsx
@@ -9,10 +9,9 @@ const ContentImgUploadBtn = ({ docData, docDispatch }) => {
     const { selectionStart, selectionEnd } = target;
     if (selectionStart !== selectionEnd) return;
     const prevContent = !docData.content ? '' : docData.content;
-    const content = `![${target.files[0].name}](${
-      prevContent.substring(0, selectionStart) + imgUrl + prevContent.substring(selectionStart, prevContent.length)
-    })`;
-
+    const content = `${prevContent.substring(0, selectionStart)}![${
+      target.files[0].name
+    }](${imgUrl})${prevContent.substring(selectionStart, prevContent.length)}`;
     docDispatch({
       type: 'INPUT_DOC_DATA',
       payload: {

--- a/client/src/components/make-section/make-section-components/ContentImgUploadBtn.jsx
+++ b/client/src/components/make-section/make-section-components/ContentImgUploadBtn.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import styled from 'styled-components';
+import { fileUploadValidator } from '../../../utils/validator';
+import { getImgUrl, showErrorCode } from '../../../services/image-upload';
+
+const ContentImgUploadBtn = ({ docData, docDispatch }) => {
+  const appendImageLink = (imgUrl, target) => {
+    const { selectionStart, selectionEnd } = target;
+    if (selectionStart !== selectionEnd) return;
+    const prevContent = !docData.content ? '' : docData.content;
+    const content = `![${target.files[0].name}](${
+      prevContent.substring(0, selectionStart) + imgUrl + prevContent.substring(selectionStart, prevContent.length)
+    })`;
+
+    docDispatch({
+      type: 'INPUT_DOC_DATA',
+      payload: {
+        content,
+      },
+    });
+  };
+
+  const contentImgInput = async (e) => {
+    if (e.target.files && e.target.files[0]) {
+      const errorCode = fileUploadValidator(e.target.files);
+      if (errorCode > 0) {
+        showErrorCode(errorCode);
+        return;
+      }
+      console.log('hello');
+      const url = await getImgUrl(e.target.files[0], 1);
+      appendImageLink(url, e.target);
+    }
+  };
+  return (
+    <>
+      <UploadBtn type="file" id="imgUpload" accept="image/*" onChange={contentImgInput} />
+      <UploadLabel htmlFor="imgUpload">이미지 추가</UploadLabel>
+    </>
+  );
+};
+
+const UploadBtn = styled.input`
+  display: none;
+`;
+
+const UploadLabel = styled.label`
+  border: 1px solid red;
+`;
+
+export default ContentImgUploadBtn;

--- a/client/src/components/make-section/make-section-components/ContentImgUploadBtn.jsx
+++ b/client/src/components/make-section/make-section-components/ContentImgUploadBtn.jsx
@@ -6,12 +6,15 @@ import { getImgUrl, showErrorCode } from '../../../services/image-upload';
 
 const ContentImgUploadBtn = ({ docData, docDispatch }) => {
   const appendImageLink = (imgUrl, target) => {
-    const { selectionStart, selectionEnd } = target;
+    const { selectionStart, selectionEnd } = document.querySelector('textarea');
     if (selectionStart !== selectionEnd) return;
     const prevContent = !docData.content ? '' : docData.content;
-    const content = `${prevContent.substring(0, selectionStart)}![${
-      target.files[0].name
-    }](${imgUrl})${prevContent.substring(selectionStart, prevContent.length)}`;
+
+    const markdownImg = `![${target.files[0].name}](${imgUrl})`;
+    const content =
+      prevContent.substring(0, selectionStart) +
+      markdownImg +
+      prevContent.substring(selectionStart, prevContent.length);
     docDispatch({
       type: 'INPUT_DOC_DATA',
       payload: {
@@ -27,7 +30,6 @@ const ContentImgUploadBtn = ({ docData, docDispatch }) => {
         showErrorCode(errorCode);
         return;
       }
-      console.log('hello');
       const url = await getImgUrl(e.target.files[0], 1);
       appendImageLink(url, e.target);
     }

--- a/client/src/components/make-section/make-section-components/Editor.jsx
+++ b/client/src/components/make-section/make-section-components/Editor.jsx
@@ -52,7 +52,15 @@ const Editor = ({ docData, docDispatch }) => {
     }
   };
 
-  return <EditorBox onChange={changeHandler} onDrop={dropHandler} ref={inputRef} value={docData.content} isDragging />;
+  return (
+    <EditorBox
+      onChange={changeHandler}
+      onDrop={dropHandler}
+      ref={inputRef}
+      value={docData.content ? docData.content : ''}
+      isDragging
+    />
+  );
 };
 
 const EditorBox = styled.textarea`

--- a/client/src/components/make-section/make-section-components/Editor.jsx
+++ b/client/src/components/make-section/make-section-components/Editor.jsx
@@ -1,7 +1,7 @@
 import React, { useRef } from 'react';
 import styled from 'styled-components';
 import { font } from '../../../styles/styled-components/mixin';
-import { fileUploadValidator, fileSizeError, fileFormatError } from '../../../utils/validator';
+import { fileUploadValidator } from '../../../utils/validator';
 import { sendToStorage, showErrorCode } from '../../../services/image-upload';
 
 const Editor = ({ docData, docDispatch }) => {
@@ -22,7 +22,8 @@ const Editor = ({ docData, docDispatch }) => {
 
   const appendImageLink = (imgUrl, target) => {
     const { selectionStart, selectionEnd } = target;
-    const prevContent = docData.content;
+    if (selectionStart !== selectionEnd) return;
+    const prevContent = !docData.content ? '' : docData.content;
     const content =
       prevContent.substring(0, selectionStart) + imgUrl + prevContent.substring(selectionStart, prevContent.length);
 

--- a/client/src/components/make-section/make-section-components/EditorBox.jsx
+++ b/client/src/components/make-section/make-section-components/EditorBox.jsx
@@ -26,19 +26,21 @@ const EditorBox = ({ docData, docDispatch }) => {
   return (
     <TotalBox>
       <BoxHeader>
-        {editorTypes.map((type) => (
-          <div key={type.name}>
-            <EditorTypeRadio
-              type="radio"
-              id={type.name}
-              name="typeRadio"
-              value={type.name}
-              onChange={handleBtn}
-              checked={inputStatus === type.name}
-            />
-            <EditorTypeLabel htmlFor={type.name}>{type.text}</EditorTypeLabel>
-          </div>
-        ))}
+        <EditorTypeWrapper>
+          {editorTypes.map((type) => (
+            <div key={type.name}>
+              <EditorTypeRadio
+                type="radio"
+                id={type.name}
+                name="typeRadio"
+                value={type.name}
+                onChange={handleBtn}
+                checked={inputStatus === type.name}
+              />
+              <EditorTypeLabel htmlFor={type.name}>{type.text}</EditorTypeLabel>
+            </div>
+          ))}
+        </EditorTypeWrapper>
         <ContentImgUploadBtn docData={docData} docDispatch={docDispatch} />
       </BoxHeader>
 
@@ -59,7 +61,7 @@ const TotalBox = styled.div`
 `;
 
 const BoxHeader = styled.div`
-  ${flexBox({})}
+  ${flexBox({ justifyContent: 'space-between' })}
   width: 100%;
   height: 43px;
   margin-bottom: 10px;
@@ -68,6 +70,11 @@ const BoxHeader = styled.div`
   border-bottom: 2px solid #d7d7d7;
   padding-top: 7px;
   padding-left: 9px;
+  padding-right: 9px;
+`;
+
+const EditorTypeWrapper = styled.div`
+  ${flexBox({})};
 `;
 
 const EditorTypeLabel = styled.label`

--- a/client/src/components/make-section/make-section-components/EditorBox.jsx
+++ b/client/src/components/make-section/make-section-components/EditorBox.jsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import EditorWithPreview from './EditorWithPreview';
 import Editor from './Editor';
 import Preview from './Preview';
+import ContentImgUploadBtn from './ContentImgUploadBtn';
 import { flexBox, font } from '../../../styles/styled-components/mixin';
 
 const EditorBox = ({ docData, docDispatch }) => {
@@ -38,6 +39,7 @@ const EditorBox = ({ docData, docDispatch }) => {
             <EditorTypeLabel htmlFor={type.name}>{type.text}</EditorTypeLabel>
           </div>
         ))}
+        <ContentImgUploadBtn docData={docData} docDispatch={docDispatch} />
       </BoxHeader>
 
       {editorTypes.map((type) => (

--- a/client/src/services/image-upload.js
+++ b/client/src/services/image-upload.js
@@ -2,7 +2,6 @@ import { fileSizeError, fileFormatError } from '../utils/validator';
 
 export const getImgUrl = async (item, type = 0) => {
   const image = item;
-  console.log(item);
   const datas = new FormData();
   datas.append('image', image, image.name);
   const result = await fetch('/api/images', {

--- a/client/src/services/image-upload.js
+++ b/client/src/services/image-upload.js
@@ -1,7 +1,23 @@
+import imageCompression from 'browser-image-compression';
 import { fileSizeError, fileFormatError } from '../utils/validator';
 
+const options = {
+  maxSizeMB: 1,
+  maxWidthOrHeight: 1920,
+  useWebWorker: true,
+};
+
+const imageCompress = async (item) => {
+  try {
+    return await imageCompression(item, options);
+  } catch (error) {
+    console.log(error);
+    return error;
+  }
+};
+
 export const getImgUrl = async (item, type = 0) => {
-  const image = item;
+  const image = !item.type.match(/gif/) ? await imageCompress(item) : item;
   const datas = new FormData();
   datas.append('image', image, image.name);
   const result = await fetch('/api/images', {

--- a/server/src/api/images.ts
+++ b/server/src/api/images.ts
@@ -8,9 +8,6 @@ const router = express.Router();
 
 const upload = multer();
 
-// const endpoint = new AWS.Endpoint(config.IMG_STORAGE_ENDPOINT);
-
-// router.post('/', upload.single('image'), (req: express.Request, res: express.Response) => {
 router.post('/', upload.single('image'), async (req: any, res: express.Response) => {
   const S3 = new AWS.S3({
     endpoint: config.IMG_STORAGE_ENDPOINT,
@@ -20,7 +17,6 @@ router.post('/', upload.single('image'), async (req: any, res: express.Response)
       secretAccessKey: config.SECRET_KEY,
     },
   });
-
   const imageName = uuidv4();
   await S3.putObject({
     Bucket: config.IMG_BUCKET_NAME,


### PR DESCRIPTION
## 작업 내역
- 이미지 추가 버튼을 통한 이미지 업로드 기능 구현
- 문서 생성 페이지의 본문 에디터 헤더에 이미지 업로드 버튼 스타일링 진행
- 새로운 이미지의 링크가 본문에 정상적으로 추가되지 않던 에러 수정
- 현재 커서 위치에 알맞게 추가되도록 변경
- 이미지 크기를 조정하여 최적화 진행
- 이미지 width와 height를 설정
#127 
#136 
