### PR TITLE
feat: 에디터 꾸밈 효과 버튼 구현

### DIFF
--- a/client/src/components/make-section/make-section-components/ContentEditIcon.jsx
+++ b/client/src/components/make-section/make-section-components/ContentEditIcon.jsx
@@ -1,0 +1,58 @@
+import React, { useCallback } from 'react';
+import styled from 'styled-components';
+import boldIcon from '../../../resource/img/bold-icon.svg';
+import italicIcon from '../../../resource/img/italic-icon.svg';
+import textLineIcon from '../../../resource/img/text-line-icon.svg';
+
+const addDecoration = {
+  bold: '**',
+  italic: '*',
+  strikeout: '~',
+};
+
+const makeNewContent = (content, decoration, start, end) => {
+  const decoLen = decoration.length;
+  const prevText = content.substring(start - decoLen, start);
+  const nextText = content.substring(end, end + decoLen);
+  const selectText = content.substring(start, end);
+  const newSelectText =
+    prevText === nextText && prevText === decoration ? selectText : decoration + selectText + decoration;
+  if (prevText === nextText && prevText === decoration)
+    return content.substring(0, start - decoLen) + newSelectText + content.substring(end + decoLen, content.lengt);
+  return content.substring(0, start) + newSelectText + content.substring(end, content.lengt);
+};
+
+const ContentEditIcon = ({ docData, docDispatch }) => {
+  const editContentByBtn = useCallback(
+    (e) => {
+      const { selectionStart, selectionEnd } = document.querySelector('textarea');
+      if (selectionStart !== selectionEnd) {
+        const content = makeNewContent(docData.content, addDecoration[e.target.id], selectionStart, selectionEnd);
+        docDispatch({
+          type: 'INPUT_DOC_DATA',
+          payload: {
+            content,
+          },
+        });
+      }
+    },
+    [docData.content],
+  );
+  return (
+    <>
+      <EditorIcon src={boldIcon} id="bold" alt="bold" onClick={editContentByBtn} />
+      <EditorIcon src={italicIcon} id="italic" alt="italic" onClick={editContentByBtn} />
+      <EditorIcon src={textLineIcon} id="strikeout" alt="strikeout" onClick={editContentByBtn} />
+    </>
+  );
+};
+
+const EditorIcon = styled.img`
+  width: 25px;
+  height: 25px;
+  &:hover {
+    cursor: pointer;
+  }
+`;
+
+export default ContentEditIcon;

--- a/client/src/components/make-section/make-section-components/ContentEditIcon.jsx
+++ b/client/src/components/make-section/make-section-components/ContentEditIcon.jsx
@@ -10,16 +10,38 @@ const addDecoration = {
   strikeout: '~',
 };
 
-const makeNewContent = (content, decoration, start, end) => {
-  const decoLen = decoration.length;
+const includeDecoInSelectRange = (content, decoration, start, end, decoLen) => {
+  const prevText = content.substring(start, start + decoLen);
+  const nextText = content.substring(end - decoLen, end);
+  if (prevText === nextText && prevText === decoration) {
+    return true;
+  }
+  return false;
+};
+
+const notIncludeDecoInSelectRange = (content, decoration, start, end, decoLen) => {
   const prevText = content.substring(start - decoLen, start);
   const nextText = content.substring(end, end + decoLen);
-  const selectText = content.substring(start, end);
-  const newSelectText =
-    prevText === nextText && prevText === decoration ? selectText : decoration + selectText + decoration;
-  if (prevText === nextText && prevText === decoration)
-    return content.substring(0, start - decoLen) + newSelectText + content.substring(end + decoLen, content.lengt);
-  return content.substring(0, start) + newSelectText + content.substring(end, content.lengt);
+  if (prevText === nextText && prevText === decoration) {
+    return true;
+  }
+  return false;
+};
+
+const makeNewContent = (content, decoration, start, end) => {
+  const decoLen = decoration.length;
+  let newSelectText = decoration + content.substring(start, end) + decoration;
+  let total = content.substring(0, start) + newSelectText + content.substring(end, content.lengt);
+
+  if (includeDecoInSelectRange(content, decoration, start, end, decoLen)) {
+    newSelectText = content.substring(start + decoLen, end - decoLen);
+    total = content.substring(0, start) + newSelectText + content.substring(end, content.lengt);
+  } else if (notIncludeDecoInSelectRange(content, decoration, start, end, decoLen)) {
+    newSelectText = content.substring(start, end);
+    total = content.substring(0, start - decoLen) + newSelectText + content.substring(end + decoLen, content.lengt);
+  }
+
+  return total;
 };
 
 const ContentEditIcon = ({ docData, docDispatch }) => {

--- a/client/src/components/make-section/make-section-components/ContentEditIcon.jsx
+++ b/client/src/components/make-section/make-section-components/ContentEditIcon.jsx
@@ -10,18 +10,9 @@ const addDecoration = {
   strikeout: '~',
 };
 
-const includeDecoInSelectRange = (content, decoration, start, end, decoLen) => {
-  const prevText = content.substring(start, start + decoLen);
-  const nextText = content.substring(end - decoLen, end);
-  if (prevText === nextText && prevText === decoration) {
-    return true;
-  }
-  return false;
-};
-
-const notIncludeDecoInSelectRange = (content, decoration, start, end, decoLen) => {
-  const prevText = content.substring(start - decoLen, start);
-  const nextText = content.substring(end, end + decoLen);
+const isDecoInSelectRange = (content, decoration, prevStart, prevEnd, nextStart, nextEnd) => {
+  const prevText = content.substring(prevStart, prevEnd);
+  const nextText = content.substring(nextStart, nextEnd);
   if (prevText === nextText && prevText === decoration) {
     return true;
   }
@@ -31,17 +22,16 @@ const notIncludeDecoInSelectRange = (content, decoration, start, end, decoLen) =
 const makeNewContent = (content, decoration, start, end) => {
   const decoLen = decoration.length;
   let newSelectText = decoration + content.substring(start, end) + decoration;
-  let total = content.substring(0, start) + newSelectText + content.substring(end, content.lengt);
-
-  if (includeDecoInSelectRange(content, decoration, start, end, decoLen)) {
+  let totalContent = content.substring(0, start) + newSelectText + content.substring(end, content.lengt);
+  if (isDecoInSelectRange(content, decoration, start, start + decoLen, end - decoLen, end)) {
     newSelectText = content.substring(start + decoLen, end - decoLen);
-    total = content.substring(0, start) + newSelectText + content.substring(end, content.lengt);
-  } else if (notIncludeDecoInSelectRange(content, decoration, start, end, decoLen)) {
+    totalContent = content.substring(0, start) + newSelectText + content.substring(end, content.lengt);
+  } else if (isDecoInSelectRange(content, decoration, start - decoLen, start, end, end + decoLen)) {
     newSelectText = content.substring(start, end);
-    total = content.substring(0, start - decoLen) + newSelectText + content.substring(end + decoLen, content.lengt);
+    totalContent =
+      content.substring(0, start - decoLen) + newSelectText + content.substring(end + decoLen, content.lengt);
   }
-
-  return total;
+  return totalContent;
 };
 
 const ContentEditIcon = ({ docData, docDispatch }) => {

--- a/client/src/components/make-section/make-section-components/ContentImgUploadBtn.jsx
+++ b/client/src/components/make-section/make-section-components/ContentImgUploadBtn.jsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { font, flexBox } from '../../../styles/styled-components/mixin';
 import { fileUploadValidator } from '../../../utils/validator';
 import { getImgUrl, showErrorCode } from '../../../services/image-upload';
+import imageUploadIcon from '../../../resource/img/image-upload-icon.svg';
 
 const ContentImgUploadBtn = ({ docData, docDispatch }) => {
   const appendImageLink = (imgUrl, target) => {
@@ -37,7 +38,9 @@ const ContentImgUploadBtn = ({ docData, docDispatch }) => {
   return (
     <>
       <UploadBtn type="file" id="imgUpload" accept="image/*" onChange={contentImgInput} />
-      <UploadLabel htmlFor="imgUpload">이미지 추가</UploadLabel>
+      <UploadLabel htmlFor="imgUpload">
+        <UploadIcon src={imageUploadIcon} alt="imgaeUploadBtn" />
+      </UploadLabel>
     </>
   );
 };
@@ -46,18 +49,16 @@ const UploadBtn = styled.input`
   display: none;
 `;
 
-const UploadLabel = styled.label`
-  ${flexBox({ justifyContent: 'center', alignItems: 'center' })};
-  ${font({ size: '13px', weight: '500' })};
-  width: 80px;
-  height: 30px;
-  background-color: black;
-  color: white;
-  border-radius: 5px;
-
+const UploadIcon = styled.img`
+  width: 25px;
+  height: 25px;
   &:hover {
     cursor: pointer;
   }
+`;
+
+const UploadLabel = styled.label`
+  ${flexBox({ justifyContent: 'center', alignItems: 'center' })};
 `;
 
 export default ContentImgUploadBtn;

--- a/client/src/components/make-section/make-section-components/EditorBox.jsx
+++ b/client/src/components/make-section/make-section-components/EditorBox.jsx
@@ -4,7 +4,9 @@ import EditorWithPreview from './EditorWithPreview';
 import Editor from './Editor';
 import Preview from './Preview';
 import ContentImgUploadBtn from './ContentImgUploadBtn';
+import ContentEditIcon from './ContentEditIcon';
 import { flexBox, font } from '../../../styles/styled-components/mixin';
+import { BREAK_POINT_MOBILE } from '../../../utils/display-width';
 
 const EditorBox = ({ docData, docDispatch }) => {
   const [inputStatus, setInputStatus] = useState('editor');
@@ -41,7 +43,10 @@ const EditorBox = ({ docData, docDispatch }) => {
             </div>
           ))}
         </EditorTypeWrapper>
-        <ContentImgUploadBtn docData={docData} docDispatch={docDispatch} />
+        <EditorFunctionIconWrapper>
+          <ContentEditIcon docData={docData} docDispatch={docDispatch} />
+          <ContentImgUploadBtn docData={docData} docDispatch={docDispatch} />
+        </EditorFunctionIconWrapper>
       </BoxHeader>
 
       {editorTypes.map((type) => (
@@ -75,6 +80,17 @@ const BoxHeader = styled.div`
 
 const EditorTypeWrapper = styled.div`
   ${flexBox({})};
+  div:nth-child(3) {
+    @media only screen and (max-width: ${BREAK_POINT_MOBILE}px) {
+      display: none;
+    }
+  }
+`;
+
+const EditorFunctionIconWrapper = styled.div`
+  ${flexBox({ justifyContent: 'space-around' })}
+  width: 132px;
+  height: 25px;
 `;
 
 const EditorTypeLabel = styled.label`

--- a/client/src/components/make-section/make-section-components/EditorWithPreview.jsx
+++ b/client/src/components/make-section/make-section-components/EditorWithPreview.jsx
@@ -12,8 +12,6 @@ const EditorWithPreview = ({ docData, docDispatch }) => {
       <HalfEditor>
         <Editor docData={docData} docDispatch={docDispatch} withPreview={withPreview} />
       </HalfEditor>
-      {/* <HalfEditor docData={docData} docDispatch={docDispatch} /> */}
-      {/* <HalfEditor /> onChange={changeHandler} value={docData.content} onDrop={dropHandler} /> */}
       <Preview>
         <MdParser content={docData.content} />
       </Preview>


### PR DESCRIPTION
- 굵게, 기울임, 취소선을 제공하는 버튼을 제공
- 범위를 지정하고 버튼을 누르면 꾸밈효과 제공
- 꾸밈 효과가 지정된 범위를 다시 선택 후 다시 버튼을 누르면 꾸밈효과 제거
- 꾸밈효과를 준 다음 드래그 범위에 따라 포괄적으로 적용되도록 변경
- 꾸밈효과를 포함하여 드래그 하여도 작동하도록 구현
- 꾸밈효과를 포함하지 않도록 드래그 하여도 작동하도록 구현

## 작업 내역
<!-- 이슈 번호 기록 -->
#148 
## 특이 사항
<!-- 버그 존재 시 이슈 번호 기록 -->
일부 쓰이지 않던 주석 처리된 코드들 제거하였습니다. (EditorWithPriview.jsx)
그 외엔 특이 사항 없습니다.

<!-- 리뷰어 지정 -->


